### PR TITLE
Fix indentation issues causing compiler errors

### DIFF
--- a/src/Polynomial.cpp
+++ b/src/Polynomial.cpp
@@ -140,7 +140,7 @@ void Intervals::writeOffset(double t) const
 	}
 	else
 	{
-      if(LaTeX) *report << "$";
+		if(LaTeX) *report << "$";
 		for(vector< pair<intervalEnd,intervalEnd> >::const_iterator i = intervals.begin(); i != intervals.end();)
 		{
 

--- a/src/Proposition.cpp
+++ b/src/Proposition.cpp
@@ -3074,7 +3074,7 @@ string Comparison::getExprnString(const expression * e,const Environment & bs) c
 		s += ")";
 
 
-      if(LaTeX) return "\\exprn{"+ s + "}";
+		if(LaTeX) return "\\exprn{"+ s + "}";
 		return s;
 
 	};
@@ -3146,7 +3146,7 @@ string Comparison::getExprnString(const expression * e,const Environment & bs, c
 	{
 		const FuncExp * fexp = s->getValidator()->fef.buildFuncExp(dynamic_cast<const func_term*>(e),bs);
 
-      if(LaTeX) return "\\exprn{"+ toString(fexp)  + "}$[=" + toString(fexp->evaluate(s)) + "]$";
+		if(LaTeX) return "\\exprn{"+ toString(fexp)  + "}$[=" + toString(fexp->evaluate(s)) + "]$";
 		return toString(fexp) + "[=" + toString(fexp->evaluate(s)) + "]";
 
 	};

--- a/src/RobustAnalyse.cpp
+++ b/src/RobustAnalyse.cpp
@@ -688,7 +688,7 @@ void RobustPlanAnalyser::calculatePNERobustness(double & robustnessOfPlan,double
 
 string getPlanStepString(const plan_step * ps)
 {
-    if(ps == 0) return "";
+		if(ps == 0) return "";
 		string act = "("+ps->op_sym->getName();
 		for(typed_symbol_list<const_symbol>::const_iterator j = ps->params->begin();
 			j != ps->params->end(); ++j)

--- a/src/Validator.cpp
+++ b/src/Validator.cpp
@@ -3213,9 +3213,9 @@ pair<const plan_step *,pair<bool,bool> > PlanRepair::repairPlanOneAction(const p
 
 
             if(planRepairValidator->getErrorLog().getConditions().size() == 0)
-	      {  if(planRepairValidator->checkGoal(theGoal)) //goalSatisfied = true;
+	      {
                     //cout << "Satisfied "<< actionName << " at time "<<actionTime<<"\n";
-               actionFixed = true; planRepaired = true; break;
+	           actionFixed = true; planRepaired = true; break;
             };
 
 


### PR DESCRIPTION
This should fix #18.

I'm not sure if the indentation in `Validator.cpp` is correct. It seems like the condition `if(planRepairValidator->checkGoal(theGoal))` was supposed to scope only over `goalSatisfied = true;`, but someone with a better understanding of the code should check if this is correct.