### PR TITLE
Avoid copy constructor and conversion from std::string& to const char*

### DIFF
--- a/applications/ValStep/src/main.cpp
+++ b/applications/ValStep/src/main.cpp
@@ -570,7 +570,7 @@ int main(int argc, char *argv[]) {
   int aID = 1;
 
   if (fromFile){
-    ifstream fin = ifstream(inputF);
+    ifstream fin(inputF.c_str());
     runValStep(fin,vld,aID);
   } else
     runValStep(cin,vld,aID);


### PR DESCRIPTION
`bash build_linux64.sh` worked only after making the one line change in this commit. Looks like you can't copy construct on ifstream and there is no known conversion from std::string& to const char*. I am on an Ubuntu 14.04 system.