### PR TITLE
Increase the compatibility with modern compiler

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -25,7 +25,8 @@
         {
             "name": "WSL",
             "includePath": [
-                "${workspaceRoot}"
+                "${workspaceRoot}",
+                "${workspaceFolder}/libraries/VAL/include"
             ],
             "defines": [
                 "__linux__",

--- a/applications/PlanRec/src/main.cpp
+++ b/applications/PlanRec/src/main.cpp
@@ -287,7 +287,7 @@ void executePlans(int &argc, char *argv[], int &argcount, TypeChecker &tc,
       };
 
       if (pr.getValidator().graphsToShow()) showGraphs = true;
-    } catch (exception &e) {
+    } catch (const exception &e) {
       if (LaTeX) {
         *report << "\\error \\\\\n";
         *report << "\\end{tabbing}\n";

--- a/applications/Relax/src/main.cpp
+++ b/applications/Relax/src/main.cpp
@@ -47,7 +47,6 @@ int main(int argc, char *argv[]) {
   yydebug = 0;  // Set to 1 to output yacc trace
 
   cout << "Processing file: " << argv[1] << '\n';
-  RelaxTranslator *dyna = 0;
 
   if (current_in_stream.bad()) {
     cout << "Failed to open\n";
@@ -62,12 +61,7 @@ int main(int argc, char *argv[]) {
     yyparse();
 
     // Output syntax tree
-    dyna = new RelaxTranslator(current_analysis);
-    auto_ptr< WriteController > ts = auto_ptr< WriteController >(dyna);
-    // NOTE: We pass responsibility for dyna into parse_category. There
-    // is no need to garbage collect it. BUT we access dyna later through
-    // this pointer, so beware!
-    parse_category::setWriteController(ts);
+    parse_category::setWriteController(std::make_unique< RelaxTranslator >(current_analysis));
     if (top_thing) {
       string nm(argv[1]);
       nm += ".rlx";

--- a/applications/Validate/src/main.cpp
+++ b/applications/Validate/src/main.cpp
@@ -334,7 +334,7 @@ void executePlans(int &argc, char *argv[], int &argcount, TypeChecker &tc,
       };
 
       if (pr.getValidator().graphsToShow()) showGraphs = true;
-    } catch (exception &e) {
+    } catch (const exception &e) {
       if (LaTeX) {
         *report << "\\error \\\\\n";
         *report << "\\end{tabbing}\n";
@@ -827,7 +827,7 @@ int main(int argc, char *argv[]) {
     // LaTeX footer
     if (LaTeX) latex.LaTeXEnd();
 
-  } catch (exception &e) {
+  } catch (const exception &e) {
     cerr << "Error: " << e.what() << "\n";
     an_analysis.error_list.report();
     return -1;

--- a/libraries/VAL/include/FastEnvironment.h
+++ b/libraries/VAL/include/FastEnvironment.h
@@ -47,10 +47,10 @@ namespace VAL {
 
   class id_var_symbol_table : public var_symbol_table {
    private:
-    IDSymbolFactory< var_symbol > *symFac;
+    std::shared_ptr<IDSymbolFactory< var_symbol >> symFac;
 
    public:
-    id_var_symbol_table() : symFac(new IDSymbolFactory< var_symbol >()) {
+    id_var_symbol_table() : symFac( std::make_shared<IDSymbolFactory< var_symbol>>()) {
       setFactory(symFac);
     };
     id_var_symbol_table(id_var_symbol_table *i)

--- a/libraries/VAL/include/RepairAdvice.h
+++ b/libraries/VAL/include/RepairAdvice.h
@@ -148,20 +148,18 @@ namespace VAL {
 
   class ErrorLog {
    private:
-    static auto_ptr< UnsatConditionFactory > fac;
+    static std::unique_ptr< UnsatConditionFactory > fac;
 
     vector< const UnsatCondition * > conditions;
 
    public:
     template < typename Fac >
     static void replace() {
-      auto_ptr< Fac > f(new Fac);
-      fac = f;
+      fac = std::make_unique<Fac>();
     };
     template < typename Fac >
-    static void replace(Fac *f) {
-      auto_ptr< Fac > nf(f);
-      fac = nf;
+    static void replace(std::unique_ptr<Fac> f) {
+      fac = std::move(f);
     };
     ErrorLog(){};
     ~ErrorLog();

--- a/libraries/VAL/include/TypedAnalyser.h
+++ b/libraries/VAL/include/TypedAnalyser.h
@@ -694,7 +694,7 @@ namespace VAL {
 
   class Associater {
    public:
-    static auto_ptr< EPSBuilder > buildEPS;
+    static std::unique_ptr< EPSBuilder > buildEPS;
     virtual ~Associater(){};
     virtual Associater *lookup(pddl_type *p) { return 0; };
 

--- a/libraries/VAL/include/ptree.h
+++ b/libraries/VAL/include/ptree.h
@@ -207,7 +207,7 @@ namespace VAL {
 
   class parse_category {
    protected:
-    static auto_ptr< WriteController > wcntr;
+    static std::unique_ptr< WriteController > wcntr;
 
    public:
     parse_category(){};
@@ -215,7 +215,7 @@ namespace VAL {
     virtual void display(int ind) const;
     virtual void write(ostream& o) const {};
     virtual void visit(VisitController* v) const {};
-    static void setWriteController(auto_ptr< WriteController > w);
+    static void setWriteController(std::unique_ptr< WriteController > w);
     static WriteController* recoverWriteController();
   };
 
@@ -286,21 +286,18 @@ namespace VAL {
   class symbol_table : public map< string, symbol_class* > {
    private:
     typedef map< string, symbol_class* > _Base;
-    auto_ptr< SymbolFactory< symbol_class > > factory;
+    std::shared_ptr< SymbolFactory< symbol_class > > factory;
 
    public:
-    symbol_table() : factory(new SymbolFactory< symbol_class >()){};
+    symbol_table() : factory(std::make_unique<SymbolFactory<symbol_class>>()){};
 
-    void setFactory(SymbolFactory< symbol_class >* sf) {
-      auto_ptr< SymbolFactory< symbol_class > > x(sf);
-      factory = x;
+    void setFactory(std::shared_ptr<SymbolFactory<symbol_class>> sf) {
+      factory = sf;
     };
 
     template < class T >
     void replaceFactory() {
-      auto_ptr< SymbolFactory< symbol_class > > x(
-          new SpecialistSymbolFactory< symbol_class, T >());
-      factory = x;
+      factory = std::make_shared<SpecialistSymbolFactory< symbol_class, T>>();
     };
 
     typedef typename _Base::iterator iterator;
@@ -1761,8 +1758,8 @@ namespace VAL {
 
   class analysis {
    private:
-    auto_ptr< VarTabFactory > varTabFactory;
-    auto_ptr< StructureFactory > strucFactory;
+    std::shared_ptr< VarTabFactory > varTabFactory;
+    std::shared_ptr< StructureFactory > strucFactory;
 
    public:
     var_symbol_table* buildPredTab() { return varTabFactory->buildPredTab(); };
@@ -1792,14 +1789,12 @@ namespace VAL {
       return strucFactory->buildProcess(nm, ps, pre, effs, st);
     };
 
-    void setFactory(VarTabFactory* vf) {
-      auto_ptr< VarTabFactory > x(vf);
-      varTabFactory = x;
+    void setFactory(std::shared_ptr<VarTabFactory> vf) {
+      varTabFactory = vf;
     };
 
-    void setFactory(StructureFactory* sf) {
-      auto_ptr< StructureFactory > x(sf);
-      strucFactory = x;
+    void setFactory(std::shared_ptr<StructureFactory> sf) {
+      strucFactory = sf;
     };
 
     var_symbol_table_stack var_tab_stack;

--- a/libraries/VAL/src/Action.cpp
+++ b/libraries/VAL/src/Action.cpp
@@ -146,7 +146,7 @@ namespace VAL {
     try {
       vld->getErrorLog().addUnsatInvariant(t - pre->getEndOfInterval(), t,
                                            pre->getIntervals(s), this, s);
-    } catch (PolyRootError &prError) {
+    } catch (const PolyRootError &prError) {
       vld->getErrorLog().addUnsatInvariant(t - pre->getEndOfInterval(), t,
                                            Intervals(), this, s, true);
     };

--- a/libraries/VAL/src/Events.cpp
+++ b/libraries/VAL/src/Events.cpp
@@ -639,7 +639,7 @@ namespace VAL {
       try {
         eventIntervals =
             (*e)->getPrecondition()->getIntervals(&(v->getState()));
-      } catch (BadAccessError &e) {
+      } catch (const BadAccessError &e) {
         // if a PNE is not defined, then no problem, the event is simply not
         // triggered
       };
@@ -1837,7 +1837,7 @@ namespace VAL {
             propSatisfied = prop->evaluateAtPointWithinError(&vld->getState());
           else
             propSatisfied = prop->evaluate(&vld->getState());
-        } catch (BadAccessError &e) {
+        } catch (const BadAccessError &e) {
           if (!neg)
             propSatisfied = false;
           else

--- a/libraries/VAL/src/Polynomial.cpp
+++ b/libraries/VAL/src/Polynomial.cpp
@@ -1178,7 +1178,7 @@ namespace VAL {
 
       try {
         roots = aPoly.getRoots(t);
-      } catch (PolyRootError &pre) {
+      } catch (const PolyRootError &pre) {
         throw pre;
       };
 
@@ -1500,7 +1500,7 @@ namespace VAL {
 
       try {
         roots = aPoly.getRoots(t);
-      } catch (PolyRootError &pre) {
+      } catch (const PolyRootError &pre) {
         throw pre;
       };
 
@@ -1542,7 +1542,7 @@ namespace VAL {
 
         try {
           roots = aPoly.getRoots(t);
-        } catch (PolyRootError &pre) {
+        } catch (const PolyRootError &pre) {
           throw pre;
         };
       };

--- a/libraries/VAL/src/Proposition.cpp
+++ b/libraries/VAL/src/Proposition.cpp
@@ -724,7 +724,7 @@ namespace VAL {
             (theAns.intervals.begin()->second.first == endOfInterval))
           return true;
       };
-    } catch (InvariantDisjError ide) {
+    } catch (const InvariantDisjError &ide) {
       if (InvariantWarnings) {
         if (LaTeX)
           s->getValidator()->addInvariantWarning(
@@ -1447,7 +1447,7 @@ namespace VAL {
     // check for polys we cannot find the roots of
     try {
       roots = ctsFtn->getRoots(t);
-    } catch (PolyRootError &pre)
+    } catch (const PolyRootError &pre)
 
     {
       if (InvariantWarnings) {
@@ -1484,7 +1484,7 @@ namespace VAL {
 
     try {
       roots = ctsFtn->getRoots(t);
-    } catch (PolyRootError &pre) {
+    } catch (const PolyRootError &pre) {
       // Let's see what we can do here.
       if (LaTeX)
         *report
@@ -2670,11 +2670,9 @@ namespace VAL {
        qf->getVars()->end();++i)
             {
             */
-    auto_ptr< WriteController > w(parse_category::recoverWriteController());
-    auto_ptr< WriteController > p(new PrettyPrinter());
-    parse_category::setWriteController(p);
+    parse_category::setWriteController(std::make_unique<PrettyPrinter>());
     o << *qg << "\n";
-    parse_category::setWriteController(w);
+    parse_category::setWriteController(std::unique_ptr<WriteController>(parse_category::recoverWriteController()));
     //"(QfiedGoal)";
   };
 

--- a/libraries/VAL/src/RepairAdvice.cpp
+++ b/libraries/VAL/src/RepairAdvice.cpp
@@ -7,7 +7,7 @@
 
 namespace VAL {
 
-  auto_ptr< UnsatConditionFactory > ErrorLog::fac(new UnsatConditionFactory);
+  std::unique_ptr< UnsatConditionFactory > ErrorLog::fac(std::make_unique<UnsatConditionFactory>());
 
   string UnsatCondition::getAdviceString() const {
     string ans;

--- a/libraries/VAL/src/RobustAnalyse.cpp
+++ b/libraries/VAL/src/RobustAnalyse.cpp
@@ -437,7 +437,7 @@ namespace VAL {
 
       try {
         planExecuted = testPlanValidator->execute();
-      } catch (exception &e) {
+      } catch (const exception &e) {
         cout << e.what() << "\n";
         executionError = true;
       };

--- a/libraries/VAL/src/TIM.cpp
+++ b/libraries/VAL/src/TIM.cpp
@@ -45,15 +45,15 @@ namespace TIM {
 
   void TIMstage1(char *argv[]) {
     current_analysis = new analysis;
-    IDopTabFactory *fac = new IDopTabFactory;
+    std::shared_ptr<IDopTabFactory> fac = std::make_shared<IDopTabFactory>();
     current_analysis->setFactory(fac);
     current_analysis->pred_tab.replaceFactory< holding_pred_symbol >();
     current_analysis->func_tab.replaceFactory< extended_func_symbol >();
     current_analysis->const_tab.replaceFactory< TIMobjectSymbol >();
     current_analysis->op_tab.replaceFactory< TIMactionSymbol >();
-    current_analysis->setFactory(new TIMfactory());
-    auto_ptr< EPSBuilder > eps(new specEPSBuilder< TIMpredSymbol >());
-    Associater::buildEPS = eps;
+    current_analysis->setFactory(std::make_shared<TIMfactory>());
+    Associater::buildEPS =
+        std::make_unique< specEPSBuilder< TIMpredSymbol > >();
 
     istream *current_in_stream;
     yydebug = 0;  // Set to 1 to output yacc trace

--- a/libraries/VAL/src/TypedAnalyser.cpp
+++ b/libraries/VAL/src/TypedAnalyser.cpp
@@ -101,7 +101,7 @@ namespace VAL {
 
   PropInfoFactory *PropInfoFactory::pf = 0;
 
-  auto_ptr< EPSBuilder > Associater::buildEPS(new EPSBuilder());
+  std::unique_ptr< EPSBuilder > Associater::buildEPS( std::make_unique<EPSBuilder>());
 
   // Associater associates predicates with their various type-specific versions.
   // So, if a predicate is overloaded to work with multiple types this will

--- a/libraries/VAL/src/Validator.cpp
+++ b/libraries/VAL/src/Validator.cpp
@@ -961,7 +961,7 @@ namespace VAL {
         *report << theplan << "\n";
       else
         cout << "Plan to validate:\n\n" << theplan << "\n";
-    } catch (BadAccessError) {
+    } catch (const BadAccessError&) {
       // ok here just listing the actions....!
     }
   };
@@ -2593,7 +2593,7 @@ namespace VAL {
       anError = false;
       try {
         planRepairValidator->execute();
-      } catch (exception &e) {
+      } catch (const exception &e) {
         cout << e.what() << "\n";
         anError = true;
       };
@@ -2696,7 +2696,7 @@ namespace VAL {
       anError = false;
       try {
         planRepairValidator->execute();
-      } catch (exception &e) {
+      } catch (const exception &e) {
         cout << e.what() << "\n";
         anError = true;
       };
@@ -2857,7 +2857,7 @@ namespace VAL {
 
       try {
         planRepairValidator->execute();
-      } catch (exception &e) {
+      } catch (const exception &e) {
         cout << e.what() << "\n";
       };
 

--- a/libraries/VAL/src/instantiation.cpp
+++ b/libraries/VAL/src/instantiation.cpp
@@ -991,7 +991,7 @@ namespace Inst {
           if (instantiatedValues.find((*p)->type) == instantiatedValues.end()) {
             try {
               instantiatedValues[(*p)->type] = tc.range(*p);
-            } catch (TypeException e) {
+            } catch (const TypeException &e) {
               cerr << "A problem has been encountered with your domain/problem "
                       "file.\n";
               cerr << "--------------------------------------------------------"
@@ -1008,7 +1008,7 @@ namespace Inst {
               Verbose = true;
               try {
                 instantiatedValues[(*p)->type] = tc.range(*p);
-              } catch (TypeException f) {
+              } catch (const TypeException &f) {
               }
               exit(1);
             }
@@ -2079,7 +2079,7 @@ namespace Inst {
       }
     }
 
-    auto_ptr< PDCIterator > options(pdc.getIterator());
+    std::unique_ptr< PDCIterator > options(pdc.getIterator());
 
     while (options->isValid()) {
       for (int x = 0; x < opParamCount; ++x) {
@@ -2187,7 +2187,7 @@ namespace Inst {
       }
     }
 
-    auto_ptr< PDCIterator > options(pdc.getIterator());
+    std::unique_ptr< PDCIterator > options(pdc.getIterator());
 
     while (options->isValid()) {
       for (int x = 0; x < opParamCount; ++x) {

--- a/libraries/VAL/src/ptree.cpp
+++ b/libraries/VAL/src/ptree.cpp
@@ -13,15 +13,15 @@
 
 namespace VAL {
 
-  auto_ptr< WriteController > parse_category::wcntr =
-      auto_ptr< WriteController >(new DebugWriteController);
+  std::unique_ptr< WriteController > parse_category::wcntr =
+      std::unique_ptr< WriteController >(new DebugWriteController);
 
   WriteController *parse_category::recoverWriteController() {
     return wcntr.release();
   };
 
-  void parse_category::setWriteController(auto_ptr< WriteController > w) {
-    wcntr = w;
+  void parse_category::setWriteController(std::unique_ptr< WriteController > w) {
+    wcntr = std::move(w);
   };
 
   void parse_category::display(int ind) const { TITLE(parse_category); }

--- a/libraries/VAL/src/valLib.cpp
+++ b/libraries/VAL/src/valLib.cpp
@@ -879,7 +879,7 @@ LPCSTR getState(void *v) {
   out << ")\n\n(:goal\n";
   PrettyPrinter *pp = new PrettyPrinter();
   pp->setShowType(false);
-  parse_category::setWriteController(auto_ptr< WriteController >(pp));
+  parse_category::setWriteController(std::unique_ptr< WriteController >(pp));
   current_analysis->the_problem->the_goal->write(out);
   out << "))\n";
 


### PR DESCRIPTION
I mainly replace the `std::auto_ptr` witch are deprecated since C++11 by `std::unique_ptr`.
This could also solve the issue on macos compilation.