### PR TITLE
Distinguish "Bad plan description!" failures.

### DIFF
--- a/applications/Validate/src/main.cpp
+++ b/applications/Validate/src/main.cpp
@@ -137,7 +137,15 @@ plan *getPlan(int &argc, char *argv[], int &argcount, TypeChecker &tc,
   if (!the_plan || !tc.typecheckPlan(the_plan)) {
     failed.push_back(name);
 
-    if (Silent < 2) *report << "Bad plan description!\n";
+    if (Silent < 2) {
+      *report << "Bad plan description!\n";
+      if (!the_plan) {
+        *report << "Unable to read plan file.\n";
+        }
+      else {
+        *report << "Plan failed to type-check\n";
+      }
+    }
     if (Silent > 1) *report << "failed\n";
     delete the_plan;
     the_plan = 0;

--- a/applications/Validate/src/main.cpp
+++ b/applications/Validate/src/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 - University of Strathclyde, King's College London and Schlumberger Ltd
+// Copyright 2019-2025 - University of Strathclyde, King's College London, Schlumberger Ltd and SIFT, LLC
 // This source code is licensed under the BSD license found in the LICENSE file in the root directory of this source tree.
 
 #include "Plan.h"
@@ -144,6 +144,7 @@ plan *getPlan(int &argc, char *argv[], int &argcount, TypeChecker &tc,
         }
       else {
         *report << "Plan failed to type-check\n";
+        *report << tc.planTypecheckFlaw(the_plan);
       }
     }
     if (Silent > 1) *report << "failed\n";

--- a/libraries/VAL/include/typecheck.h
+++ b/libraries/VAL/include/typecheck.h
@@ -123,6 +123,7 @@ namespace VAL {
     bool typecheckAction(const operator_ *act);
     bool typecheckProblem();
     bool typecheckPlan(const plan *p);
+    std::string planTypecheckFlaw(const plan *p);
     bool typecheckGoal(const goal *g);
     bool typecheckProposition(const proposition *g);
     bool typecheckActionInstance(const plan_step *p);

--- a/libraries/VAL/src/typecheck.cpp
+++ b/libraries/VAL/src/typecheck.cpp
@@ -7,6 +7,8 @@
 #include "ptree.h"
 #include <algorithm>
 #include <functional>
+#include <sstream>
+#include <string>
 
 namespace VAL {
 
@@ -707,6 +709,16 @@ namespace VAL {
     if (!isTyped) return true;
     return p->end() == std::find_if(p->begin(), p->end(), badchecker(this));
   };
+
+
+   std::string TypeChecker::planTypecheckFlaw(const plan *p) {
+     std::ostringstream oss;
+     oss << "Type error in:\n";
+     oss << *(std::find_if(p->begin(), p->end(), badchecker(this)));
+     oss << "\n";
+     return oss.str();
+  };
+
 
   vector< const_symbol * > TypeChecker::range(const var_symbol *v) {
     vector< const_symbol * > l;


### PR DESCRIPTION
There are 2 causes for this failure message: either the plan is missing (presumably it's ill-formatted), or the plan fails to type-check.  Give different error messages for the two cases.