### PR TITLE
Use mkdir -p in build script.

### DIFF
--- a/scripts/linux/build_linux64.sh
+++ b/scripts/linux/build_linux64.sh
@@ -13,7 +13,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUILD_DIR=$DIR/../../build
 TARGET_DIR=linux64
 
-mkdir $BUILD_DIR
+mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 
 mkdir $TARGET_DIR


### PR DESCRIPTION
Trivial fix, but  it keeps the build script from breaking if the `BUILD_DIR` already exists.